### PR TITLE
Adding Apache HTTP client support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
 
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
-
+      <uses-library android:name="org.apache.http.legacy"
+            android:required="false"/>
       <meta-data
           android:name="android.app.shortcuts"
           android:resource="@xml/shortcuts"/>


### PR DESCRIPTION
Background On Android Marshmallow, Google has completely removed the support of Apache HTTP client

Fixes #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber]

Changes: [Add here what changes were made in this issue and if possible provide links.]

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
